### PR TITLE
Contract address in `newWasmInstance`

### DIFF
--- a/elrond-config.md
+++ b/elrond-config.md
@@ -620,7 +620,7 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
                 ~> pushCallState
                 ~> transferFunds(FROM, TO, VALUE)
                 ~> transferESDTs(FROM, TO, ESDT)
-                ~> newWasmInstance(CODE)
+                ~> newWasmInstance(TO, CODE)
                 ~> mkCall(TO, FUNCNAME, VMINPUT)
                 ~> #endWasm
                    ...
@@ -656,11 +656,11 @@ Every contract call runs in its own Wasm instance initialized with the contract'
 
 ```k
     syntax WasmCell
-    syntax InternalCmd ::= newWasmInstance(ModuleDecl)  [klabel(newWasmInstance), symbol]
+    syntax InternalCmd ::= newWasmInstance(Bytes, ModuleDecl)  [klabel(newWasmInstance), symbol]
                          | "setContractModIdx"
  // ------------------------------------------------------
     rule [newWasmInstance]:
-        <commands> newWasmInstance(CODE) => #waitWasm ~> setContractModIdx ...</commands>
+        <commands> newWasmInstance(_, CODE) => #waitWasm ~> setContractModIdx ...</commands>
         ( _:WasmCell => <wasm> 
           <instrs> initContractModule(CODE) </instrs>
           ...


### PR DESCRIPTION
Add a new field to `newWasmInstance` to store the contract address. It is redundant in the semantics, but will be used for caching in `mx-backend`.