### PR TITLE
fix ESDTTransfer: amount check, call arguments

### DIFF
--- a/esdt.md
+++ b/esdt.md
@@ -161,6 +161,13 @@ module ESDT
     rule ESDTTransfer.token(ARGS) => ARGS {{ 0 }} orDefault b""
     rule ESDTTransfer.value(ARGS) => Bytes2Int(ARGS {{ 1 }} orDefault b"", BE, Unsigned)
 
+    syntax ListBytes ::= "ESDTTransfer.callArgs" "(" ListBytes ")"    [function, total]
+ // -----------------------------------------------------------------------------------
+    //                         token       amount      function
+    rule ESDTTransfer.callArgs(ListItem(_) ListItem(_) ListItem(_) ARGS) => ARGS
+    rule ESDTTransfer.callArgs(_) => .ListBytes                        [owise]
+
+
     syntax InternalCmd ::= determineIsSCCallAfter(Bytes, Bytes, VmInputCell)
         [klabel(determineIsSCCallAfter), symbol]
  // ----------------------------------------------
@@ -201,7 +208,7 @@ module ESDT
                                 </vmInput>)
       => <vmInput>
             <caller> FROM </caller>
-            <callArgs> ARGS </callArgs>
+            <callArgs> ESDTTransfer.callArgs(ARGS) </callArgs>
             <callValue> 0 </callValue>
             <esdtTransfers> ESDT </esdtTransfers>
             // gas

--- a/esdt.md
+++ b/esdt.md
@@ -144,15 +144,22 @@ module ESDT
                 ~> checkBool(size(ARGS) >=Int 2, "invalid arguments to process built-in function")
                 // TODO ~> check transfer to meta
                 // TODO ~> checkIfTransferCanHappenWithLimitedTransfer()
+                ~> checkBool(ESDTTransfer.value(ARGS) >Int 0, "negative value")
                 ~> transferESDT( SND, DST
                                , esdtTransfer(
-                                   ARGS {{ 0 }} orDefault b"",
-                                   Bytes2Int(ARGS {{ 1 }} orDefault b"", BE, Unsigned), 
+                                   ESDTTransfer.token(ARGS),
+                                   ESDTTransfer.value(ARGS), 
                                    0)
                                )
                 ~> determineIsSCCallAfter(SND, DST, VMINPUT)
                    ...
         </commands>
+
+    syntax Bytes ::= "ESDTTransfer.token"  "(" ListBytes ")"   [function, total]
+    syntax Int   ::= "ESDTTransfer.value" "(" ListBytes ")"    [function, total]
+ // -----------------------------------------------------------------------------
+    rule ESDTTransfer.token(ARGS) => ARGS {{ 0 }} orDefault b""
+    rule ESDTTransfer.value(ARGS) => Bytes2Int(ARGS {{ 1 }} orDefault b"", BE, Unsigned)
 
     syntax InternalCmd ::= determineIsSCCallAfter(Bytes, Bytes, VmInputCell)
         [klabel(determineIsSCCallAfter), symbol]


### PR DESCRIPTION
[VM code](https://github.com/multiversx/mx-chain-vm-common-go/blob/0fd015ce531d2772f26d298c7e362429843a1f38/builtInFunctions/esdtTransfer.go#L100)

```go
	value := big.NewInt(0).SetBytes(vmInput.Arguments[1])
	if value.Cmp(zero) <= 0 {
		return nil, ErrNegativeValue
	}
```