### PR TITLE
Drop . in favour of .K

### DIFF
--- a/auto-allocate.md
+++ b/auto-allocate.md
@@ -18,7 +18,7 @@ module WASM-AUTO-ALLOCATE
 
     syntax Stmt ::= "newEmptyModule" WasmString
  // -------------------------------------------
-    rule <instrs> newEmptyModule MODNAME => . ... </instrs>
+    rule <instrs> newEmptyModule MODNAME => .K ... </instrs>
          <moduleRegistry> MR => MR [ MODNAME <- NEXT ] </moduleRegistry>
          <nextModuleIdx> NEXT => NEXT +Int 1 </nextModuleIdx>
          <moduleInstances> ( .Bag => <moduleInst> <modIdx> NEXT </modIdx> ... </moduleInst>) ... </moduleInstances>
@@ -50,7 +50,7 @@ It is treated purely as a key set -- the actual stored values are not used or st
 
     syntax Instr ::= hostCall(String, String, FuncType)
  // ---------------------------------------------------
-    rule <instrs> (. => allocfunc(HOSTMOD, NEXTADDR, TYPE, [ .ValTypes ], hostCall(wasmString2StringStripped(MOD), wasmString2StringStripped(NAME), TYPE) .Instrs, #meta(... id: String2Identifier("$auto-alloc:" +String #parseWasmString(MOD) +String ":" +String #parseWasmString(NAME) ), localIds: .Map )))
+    rule <instrs> (.K => allocfunc(HOSTMOD, NEXTADDR, TYPE, [ .ValTypes ], hostCall(wasmString2StringStripped(MOD), wasmString2StringStripped(NAME), TYPE) .Instrs, #meta(... id: String2Identifier("$auto-alloc:" +String #parseWasmString(MOD) +String ":" +String #parseWasmString(NAME) ), localIds: .Map )))
                ~> #import(MOD, NAME, #funcDesc(... type: TIDX))
               ...
          </instrs>

--- a/elrond-config.md
+++ b/elrond-config.md
@@ -72,7 +72,7 @@ module ELROND-CONFIG
       requires 0 <=Int #signed(i32 , OFFSET)
        andBool #signed(i32 , OFFSET) +Int lengthBytes(BS) >Int (SIZE *Int #pageSize())
 
-    rule <instrs> #memStore(OFFSET, BS) => . ... </instrs>
+    rule <instrs> #memStore(OFFSET, BS) => .K ... </instrs>
          <contractModIdx> MODIDX:Int </contractModIdx>
          <moduleInst>
            <modIdx> MODIDX </modIdx>
@@ -100,7 +100,7 @@ module ELROND-CONFIG
       requires #signed(i32 , LENGTH) <Int 0
 
     rule [memLoad-zero-length]:
-        <instrs> #memLoad(_, 0) => . ... </instrs>
+        <instrs> #memLoad(_, 0) => .K ... </instrs>
         <bytesStack> STACK => .Bytes : STACK </bytesStack>
 
     rule [memLoad-bad-bounds]:
@@ -121,7 +121,7 @@ module ELROND-CONFIG
          orBool #signed(i32 , OFFSET) +Int #signed(i32 , LENGTH) >Int (SIZE *Int #pageSize()))
 
     rule [memLoad]:
-         <instrs> #memLoad(OFFSET, LENGTH) => . ... </instrs>
+         <instrs> #memLoad(OFFSET, LENGTH) => .K ... </instrs>
          <bytesStack> STACK => #getBytesRange(DATA, OFFSET, LENGTH) : STACK </bytesStack>
          <contractModIdx> MODIDX:Int </contractModIdx>
          <moduleInst>
@@ -189,7 +189,7 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
 
     syntax InternalInstr ::= #isReservedKey ( String )
  // --------------------------------------------------
-    rule <instrs> #isReservedKey(KEY) => . ... </instrs>
+    rule <instrs> #isReservedKey(KEY) => .K ... </instrs>
       requires notBool #hasPrefix(KEY, "ELROND")
 
     rule <instrs> #isReservedKey(KEY)
@@ -205,7 +205,7 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
          <callee> CALLEE </callee>
 
     rule [storageLoadFromAddress]:
-        <instrs> #storageLoadFromAddress => . ... </instrs>
+        <instrs> #storageLoadFromAddress => .K ... </instrs>
         <bytesStack> ADDR : KEY : STACK => #lookupStorage(STORAGE, KEY) : STACK </bytesStack>
         <account>
           <address> ADDR </address>
@@ -312,11 +312,11 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
     syntax InternalInstr ::= "#appendToOutFromBytesStack"
                            | #appendToOut ( Bytes )
  // -----------------------------------------------
-    rule <instrs> #appendToOutFromBytesStack => . ... </instrs>
+    rule <instrs> #appendToOutFromBytesStack => .K ... </instrs>
          <bytesStack> OUT : STACK => STACK </bytesStack>
          <out> ... (.ListBytes => ListItem(wrap(OUT))) </out>
 
-    rule <instrs> #appendToOut(OUT) => . ... </instrs>
+    rule <instrs> #appendToOut(OUT) => .K ... </instrs>
          <out> ... (.ListBytes => ListItem(wrap(OUT))) </out>
 ```
 
@@ -393,7 +393,7 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
          <bytesStack> DATA : STACK => STACK </bytesStack>
          <valstack> <i32> NUMTOPICS : <i32> _ : VALSTACK => VALSTACK </valstack>
 
-    rule <instrs> #writeLogAux(1, TOPICS, DATA) => . ... </instrs>
+    rule <instrs> #writeLogAux(1, TOPICS, DATA) => .K ... </instrs>
          <bytesStack> IDENTIFIER : STACK => STACK </bytesStack>
          <callee> CALLEE </callee>
          <logs> ... (.List => ListItem(logEntry(CALLEE, IDENTIFIER, TOPICS, DATA))) </logs>
@@ -415,7 +415,7 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
     syntax InternalCmd ::= "#endWasm"
  // ---------------------------------
     rule <commands> #endWasm => popCallState ~> dropWorldState ... </commands>
-         <instrs> . </instrs>
+         <instrs> .K </instrs>
          <out> OUT </out>
          <logs> LOGS </logs>
          <vmOutput> _ => VMOutput( OK , .Bytes , OUT , LOGS) </vmOutput>
@@ -423,8 +423,8 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
 
     syntax InternalCmd ::= "#waitWasm"  [klabel(#waitWasm), symbol]
  // ----------------------------------
-    rule <commands> #waitWasm => . ... </commands>
-         <instrs> . </instrs>
+    rule <commands> #waitWasm => .K ... </commands>
+         <instrs> .K </instrs>
       [priority(60)]
 ```
 
@@ -441,7 +441,7 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
         <vmOutput> .VMOutput => VMOutput( EC , MSG , .ListBytes , .List) </vmOutput>
 
     rule [exception-skip]:
-        <commands> #exception(_,_) ~> (CMD:InternalCmd => . ) ... </commands>
+        <commands> #exception(_,_) ~> (CMD:InternalCmd => .K ) ... </commands>
       requires CMD =/=K #endWasm
 
 ```
@@ -462,8 +462,8 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
         </commands>
 
     rule [throwExceptionBs]:
-        <instrs> (#throwExceptionBs( EC , MSG ) ~> _ ) => . </instrs>
-        <commands> (. => #exception(EC,MSG)) ... </commands>
+        <instrs> (#throwExceptionBs( EC , MSG ) ~> _ ) => .K </instrs>
+        <commands> (.K => #exception(EC,MSG)) ... </commands>
         <logging> S => S +String " -- Exception: " +String Bytes2String(MSG) </logging>
     rule [throwExceptionBs-cmd]:
         <commands> (#throwExceptionBs( EC , MSG ) => #exception(EC,MSG)) ... </commands>
@@ -489,7 +489,7 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
  // ------------------------------------------------------------------------------
     // ignore if the account already exists
     rule [createAccount-existing]:
-         <commands> createAccount(ADDR) => . ... </commands>
+         <commands> createAccount(ADDR) => .K ... </commands>
          <account>
            <address> ADDR </address>
            ...
@@ -498,7 +498,7 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
       [priority(60)]
 
     rule [createAccount-new]:
-         <commands> createAccount(ADDR) => . ... </commands>
+         <commands> createAccount(ADDR) => .K ... </commands>
          <accounts>
            ( .Bag
           => <account>
@@ -516,7 +516,7 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
                          | setAccountOwner     ( Bytes, Bytes )
  // ---------------------------------------------------------------
     rule [setAccountFields]:
-         <commands> setAccountFields(ADDR, NONCE, BALANCE, CODE, OWNER_ADDR, STORAGE) => . ... </commands>
+         <commands> setAccountFields(ADDR, NONCE, BALANCE, CODE, OWNER_ADDR, STORAGE) => .K ... </commands>
          <account>
            <address> ADDR </address>
            <nonce> _ => NONCE </nonce>
@@ -529,7 +529,7 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
       [priority(60)]
 
     rule [setAccountCode]:
-         <commands> setAccountCode(ADDR, CODE) => . ... </commands>
+         <commands> setAccountCode(ADDR, CODE) => .K ... </commands>
          <account>
            <address> ADDR </address>
            <code> _ => CODE </code>
@@ -537,7 +537,7 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
          </account>
       [priority(60)]
 
-    rule <commands> setAccountOwner(ADDR, OWNER) => . ... </commands>
+    rule <commands> setAccountOwner(ADDR, OWNER) => .K ... </commands>
          <account>
            <address> ADDR </address>
            <ownerAddress> _ => OWNER </ownerAddress>
@@ -603,8 +603,8 @@ TODO: Implement [reserved keys and read-only runtimes](https://github.com/Elrond
       requires VALUE >Int ORIGFROM
       [priority(60)]
 
-    rule <commands> #transferSuccess => . ... </commands>
-         <instrs> . </instrs>
+    rule <commands> #transferSuccess => .K ... </commands>
+         <instrs> .K </instrs>
 ```
 
 ## Calling Contract
@@ -706,7 +706,7 @@ Every contract call runs in its own Wasm instance initialized with the contract'
       // clause.
 
     rule [setContractModIdx]:
-        <commands> setContractModIdx => . ... </commands>
+        <commands> setContractModIdx => .K ... </commands>
         <contractModIdx> _ => NEXTIDX -Int 1 </contractModIdx>
         <nextModuleIdx> NEXTIDX </nextModuleIdx>
 
@@ -722,13 +722,13 @@ Initialize the call state and invoke the endpoint function:
 
 ```k
     rule [mkCall]:
-        <commands> mkCall(TO, FUNCNAME:WasmStringToken, VMINPUT) => . ... </commands>
+        <commands> mkCall(TO, FUNCNAME:WasmStringToken, VMINPUT) => .K ... </commands>
         <callState>
           <callee> _ => TO   </callee>
           (_:VmInputCell => VMINPUT)
           // executional
           <wasm>
-            <instrs> . => ( invoke FUNCADDRS {{ FUNCIDX }} orDefault -1 ) </instrs>
+            <instrs> .K => ( invoke FUNCADDRS {{ FUNCIDX }} orDefault -1 ) </instrs>
             <moduleInst>
               <modIdx> MODIDX </modIdx>
               <exports> ... FUNCNAME |-> FUNCIDX:Int </exports>
@@ -749,14 +749,14 @@ Initialize the call state and invoke the endpoint function:
       [priority(60)]
 
     rule [mkCall-func-not-found]:
-        <commands> mkCall(_TO, FUNCNAME:WasmStringToken, _VMINPUT) => . ... </commands>
+        <commands> mkCall(_TO, FUNCNAME:WasmStringToken, _VMINPUT) => .K ... </commands>
         <contractModIdx> MODIDX:Int </contractModIdx>
         <moduleInst>
           <modIdx> MODIDX </modIdx>
           <exports> EXPORTS </exports>
           ...
         </moduleInst>
-        <instrs> . => #throwException(FunctionNotFound, "invalid function (not found)") </instrs>
+        <instrs> .K => #throwException(FunctionNotFound, "invalid function (not found)") </instrs>
         <logging> S => S +String " -- callContract not found " +String #parseWasmString(FUNCNAME) </logging>
       requires notBool( FUNCNAME in_keys(EXPORTS) )
       [priority(60)]

--- a/elrond-node.md
+++ b/elrond-node.md
@@ -137,10 +137,10 @@ Storage maps byte arrays to byte arrays.
     syntax BytesOp ::= #pushBytes ( Bytes )
                      | "#dropBytes"
  // ---------------------------------------
-    rule <instrs> #pushBytes(BS) => . ... </instrs>
+    rule <instrs> #pushBytes(BS) => .K ... </instrs>
          <bytesStack> STACK => BS : STACK </bytesStack>
 
-    rule <instrs> #dropBytes => . ... </instrs>
+    rule <instrs> #dropBytes => .K ... </instrs>
          <bytesStack> _ : STACK => STACK </bytesStack>
 
     syntax InternalInstr ::= "#returnLength"
@@ -163,7 +163,7 @@ The `<callStack>` cell stores a list of previous contract execution states. Thes
     syntax InternalCmd ::= "pushCallState"  [klabel(pushCallState), symbol]
  // ---------------------------------------
     rule [pushCallState]:
-         <commands> pushCallState => . ... </commands>
+         <commands> pushCallState => .K ... </commands>
          <callStack> (.List => ListItem(CALLSTATE)) ... </callStack>
          <callState> CALLSTATE </callState>
       [priority(60)]
@@ -171,7 +171,7 @@ The `<callStack>` cell stores a list of previous contract execution states. Thes
     syntax InternalCmd ::= "popCallState"  [klabel(popCallState), symbol]
  // --------------------------------------
     rule [popCallState]:
-         <commands> popCallState => . ... </commands>
+         <commands> popCallState => .K ... </commands>
          <callStack> (ListItem(CALLSTATE) => .List) ... </callStack>
          <callState> _ => CALLSTATE </callState>
       [priority(60)]
@@ -179,7 +179,7 @@ The `<callStack>` cell stores a list of previous contract execution states. Thes
     syntax InternalCmd ::= "dropCallState"  [klabel(dropCallState), symbol]
  // ---------------------------------------
     rule [dropCallState]:
-         <commands> dropCallState => . ... </commands>
+         <commands> dropCallState => .K ... </commands>
          <callStack> (ListItem(_) => .List) ... </callStack>
       [priority(60)]
 ```
@@ -195,7 +195,7 @@ The `<callStack>` cell stores a list of previous contract execution states. Thes
     syntax InternalCmd ::= "pushWorldState"  [klabel(pushWorldState), symbol]
  // ---------------------------------------
     rule [pushWorldState]:
-         <commands> pushWorldState => . ... </commands>
+         <commands> pushWorldState => .K ... </commands>
          <interimStates> (.List => ListItem({ ACCTDATA })) ... </interimStates>
          <accounts>       ACCTDATA </accounts>
       [priority(60)]
@@ -203,7 +203,7 @@ The `<callStack>` cell stores a list of previous contract execution states. Thes
     syntax InternalCmd ::= "popWorldState"  [klabel(popWorldState), symbol]
  // --------------------------------------
     rule [popWorldState]:
-         <commands> popWorldState => . ... </commands>
+         <commands> popWorldState => .K ... </commands>
          <interimStates> (ListItem({ ACCTDATA }) => .List) ... </interimStates>
          <accounts>       _ => ACCTDATA </accounts>
       [priority(60)]
@@ -211,7 +211,7 @@ The `<callStack>` cell stores a list of previous contract execution states. Thes
     syntax InternalCmd ::= "dropWorldState"  [klabel(dropWorldState), symbol]
  // ---------------------------------------
     rule [dropWorldState]:
-         <commands> dropWorldState => . ... </commands>
+         <commands> dropWorldState => .K ... </commands>
          <interimStates> (ListItem(_) => .List) ... </interimStates>
       [priority(60)]
 ```
@@ -224,7 +224,7 @@ The `<callStack>` cell stores a list of previous contract execution states. Thes
     syntax InternalCmd ::= checkAccountExists( Bytes )
  // ------------------------------------------------------
     rule [checkAccountExists-pass]:
-        <commands> checkAccountExists(ADDR) => . ... </commands>
+        <commands> checkAccountExists(ADDR) => .K ... </commands>
         <account>
           <address> ADDR </address>
           ...
@@ -256,7 +256,7 @@ The `<callStack>` cell stores a list of previous contract execution states. Thes
     syntax InternalCmd ::= checkBool(Bool, String)    [klabel(checkBool), symbol]
  // -----------------------------------------------------------------------------------
     rule [checkBool-t]:
-        <commands> checkBool(true, _)    => . ... </commands>
+        <commands> checkBool(true, _)    => .K ... </commands>
     rule [checkBool-f]:
         <commands> checkBool(false, ERR) => #throwExceptionBs(ExecutionFailed, String2Bytes(ERR)) ... </commands>
 
@@ -267,8 +267,8 @@ The `<callStack>` cell stores a list of previous contract execution states. Thes
     syntax InternalCmd ::= "resetCallstate"      [klabel(resetCallState), symbol]
  // --------------------------------------------------------------------------- 
     rule [resetCallstate]:
-        <commands> resetCallstate => . ... </commands>
-        (_:CallStateCell => <callState> <instrs> . </instrs> ... </callState>)
+        <commands> resetCallstate => .K ... </commands>
+        (_:CallStateCell => <callState> <instrs> .K </instrs> ... </callState>)
 
 endmodule
 ```

--- a/esdt.md
+++ b/esdt.md
@@ -38,7 +38,7 @@ module ESDT
     syntax InternalCmd ::= checkESDTBalance(account: Bytes, token: Bytes, value: Int)
  // ------------------------------------------------------
     rule [checkESDTBalance]:
-        <commands> checkESDTBalance(ACCT, TOKEN, VALUE) => . ... </commands>
+        <commands> checkESDTBalance(ACCT, TOKEN, VALUE) => .K ... </commands>
         <account>
           <address> ACCT </address>
           <esdtData>
@@ -64,7 +64,7 @@ module ESDT
     syntax InternalCmd ::= addToESDTBalance(account: Bytes, token: Bytes, delta: Int)
  // ------------------------------------------------------
     rule [addToESDTBalance]:
-        <commands> addToESDTBalance(ACCT, TOKEN, DELTA) => . ... </commands>
+        <commands> addToESDTBalance(ACCT, TOKEN, DELTA) => .K ... </commands>
         <account>
           <address> ACCT </address>
           <esdtData>
@@ -77,7 +77,7 @@ module ESDT
       [priority(60)]
 
     rule [addToESDTBalance-new-esdtData]:
-        <commands> addToESDTBalance(ACCT, TOKEN, DELTA) => . ... </commands>
+        <commands> addToESDTBalance(ACCT, TOKEN, DELTA) => .K ... </commands>
         <account>
           <address> ACCT </address>
           (.Bag => <esdtData>
@@ -222,7 +222,7 @@ module ESDT
 
     rule [determineIsSCCallAfter-nocall]:
         <commands> determineIsSCCallAfter(_SND, _DST, _FUNC, _VMINPUT)
-                => . ...
+                => .K ...
         </commands>
       [owise]
 
@@ -320,7 +320,7 @@ module ESDT
         [klabel(checkAllowedToExecute), symbol]
  // ----------------------------------------------------------------------------------------
     rule [checkAllowedToExecute-pass]:
-        <commands> checkAllowedToExecute(ADDR, TOK, ROLE) => . ... </commands>
+        <commands> checkAllowedToExecute(ADDR, TOK, ROLE) => .K ... </commands>
         <account>
           <address> ADDR </address>
           <esdtData>

--- a/mandos.md
+++ b/mandos.md
@@ -39,47 +39,47 @@ Only take the next step once both the Elrond node and Wasm are done executing.
 ```k
     syntax Step ::= "#wait"
  // -----------------------
-    rule <k> #wait => . ... </k>
-         <commands> . </commands>
-         <instrs> . </instrs>
+    rule <k> #wait => .K ... </k>
+         <commands> .K </commands>
+         <instrs> .K </instrs>
 
     syntax Steps ::= List{Step, ""} [klabel(mandosSteps), symbol]
  // -------------------------------------------------------------
     rule [steps-empty]:
-        <k> .Steps => . </k>
-        <commands> . </commands>
+        <k> .Steps => .K </k>
+        <commands> .K </commands>
       [priority(60)]
 
     rule [steps-seq]:
         <k> S:Step SS:Steps => S ~> SS ... </k>
-        <commands> . </commands>
+        <commands> .K </commands>
       [priority(60)]
 
     syntax Step ::= "setExitCode" Int     [klabel(setExitCode), symbol]
  // -------------------------------------------------------------------
-    rule <k> setExitCode I => . ... </k>
-         <commands> . </commands>
-         <instrs> . </instrs>
+    rule <k> setExitCode I => .K ... </k>
+         <commands> .K </commands>
+         <instrs> .K </instrs>
          <exit-code> _ => I </exit-code>
       [priority(60)]
 
     syntax Step ::= ModuleDecl
  // --------------------------
     rule <k> (module _:OptionalId _:Defns):ModuleDecl #as M => #wait ... </k>
-         <instrs> . => sequenceStmts(text2abstract(M .Stmts)) </instrs>
-         <commands> . </commands>
+         <instrs> .K => sequenceStmts(text2abstract(M .Stmts)) </instrs>
+         <commands> .K </commands>
 
     rule <k> M:ModuleDecl => #wait ... </k>
-         <instrs> . => M </instrs>
-         <commands> . </commands>
+         <instrs> .K => M </instrs>
+         <commands> .K </commands>
       [owise]
 
     syntax Step ::= "register" String [klabel(register), symbol]
  // ------------------------------------------------------------
-    rule <k> register NAME => . ... </k>
+    rule <k> register NAME => .K ... </k>
          <moduleRegistry> REG => REG [NAME <- IDX -Int 1] </moduleRegistry>
          <nextModuleIdx> IDX </nextModuleIdx>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 ```
 
@@ -118,11 +118,11 @@ Only take the next step once both the Elrond node and Wasm are done executing.
  // -------------------------------------------------------------------------------
     rule <k> setAccount(ADDRESS, NONCE, BALANCE, CODE, OWNER, STORAGE)
           => setAccountAux(#address2Bytes(ADDRESS), NONCE, BALANCE, CODE, #address2Bytes(OWNER), STORAGE) ... </k>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
     rule <k> setAccountAux(ADDRESS, NONCE, BALANCE, CODE, OWNER, STORAGE) => #wait ... </k>
-         <commands> . 
+         <commands> .K 
                  => createAccount(ADDRESS)
                  ~> setAccountFields(ADDRESS, NONCE, BALANCE, CODE, OWNER, STORAGE) 
          </commands>
@@ -130,7 +130,7 @@ Only take the next step once both the Elrond node and Wasm are done executing.
 
     syntax Step ::= setEsdtBalance( Bytes , Bytes, Int )     [klabel(setEsdtBalance), symbol]
  // ------------------------------------------------
-    rule <k> setEsdtBalance( ADDR , TokId , Value ) => . ... </k>
+    rule <k> setEsdtBalance( ADDR , TokId , Value ) => .K ... </k>
         <account>
           <address> ADDR </address>
           <esdtData>
@@ -140,10 +140,10 @@ Only take the next step once both the Elrond node and Wasm are done executing.
            </esdtData>
           ...
         </account>
-        <commands> . </commands>
+        <commands> .K </commands>
       [priority(60)]
 
-    rule <k> setEsdtBalance( ADDR , TokId , Value ) => . ... </k>
+    rule <k> setEsdtBalance( ADDR , TokId , Value ) => .K ... </k>
         <account>
           <address> ADDR </address>
           <esdtDatas>
@@ -156,14 +156,14 @@ Only take the next step once both the Elrond node and Wasm are done executing.
           </esdtDatas>
           ...
         </account>
-        <commands> . </commands>
+        <commands> .K </commands>
       [priority(61)]
 
     syntax Step ::= setEsdtRoles( Bytes , Bytes , Set )
         [klabel(setEsdtRoles), symbol]
  // ----------------------------------------------------------------------------
     rule [setEsdtRoles-existing]:
-        <k> setEsdtRoles(ADDR, TOK, ROLES) => . ... </k>
+        <k> setEsdtRoles(ADDR, TOK, ROLES) => .K ... </k>
         <account>
           <address> ADDR </address>
           <esdtData>
@@ -173,11 +173,11 @@ Only take the next step once both the Elrond node and Wasm are done executing.
            </esdtData>
           ...
         </account>
-        <commands> . </commands>
+        <commands> .K </commands>
       [priority(60)]
 
     rule [setEsdtRoles-new]:
-        <k> setEsdtRoles(ADDR, TOK, ROLES) => . ... </k>
+        <k> setEsdtRoles(ADDR, TOK, ROLES) => .K ... </k>
         <account>
           <address> ADDR </address>
           <esdtDatas>
@@ -190,14 +190,14 @@ Only take the next step once both the Elrond node and Wasm are done executing.
           </esdtDatas>
           ...
         </account>
-        <commands> . </commands>
+        <commands> .K </commands>
       [priority(61)]
 
     syntax Step ::= checkEsdtRoles( Bytes , Bytes , Set )
         [klabel(checkEsdtRoles), symbol]
  // ----------------------------------------------------------------------------
     rule [checkEsdtRoles]:
-        <k> checkEsdtRoles(ADDR, TOK, ROLES) => . ... </k>
+        <k> checkEsdtRoles(ADDR, TOK, ROLES) => .K ... </k>
         <account>
           <address> ADDR </address>
           <esdtData>
@@ -207,7 +207,7 @@ Only take the next step once both the Elrond node and Wasm are done executing.
            </esdtData>
           ...
         </account>
-        <commands> . </commands>
+        <commands> .K </commands>
       [priority(60)]
 
     syntax Step ::= newAddress    ( Address, Int, Address ) [klabel(newAddress), symbol]
@@ -215,12 +215,12 @@ Only take the next step once both the Elrond node and Wasm are done executing.
  // ---------------------------------------------------------------------------------------
     rule <k> newAddress(CREATOR, NONCE, NEW)
           => newAddressAux(#address2Bytes(CREATOR), NONCE, #address2Bytes(NEW)) ... </k>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> newAddressAux(CREATOR, NONCE, NEW) => . ... </k>
+    rule <k> newAddressAux(CREATOR, NONCE, NEW) => .K ... </k>
          <newAddresses> NEWADDRESSES => NEWADDRESSES [tuple(CREATOR, NONCE) <- NEW] </newAddresses>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
     syntax AddressNonce ::= tuple( Bytes , Int )
@@ -234,54 +234,54 @@ Only take the next step once both the Elrond node and Wasm are done executing.
                        | blockEpoch      ( Int )   [klabel(blockEpoch), symbol]
                        | blockRandomSeed ( Bytes ) [klabel(blockRandomSeed), symbol]
  // --------------------------------------------------------------------------------
-    rule <k> setCurBlockInfo(blockTimestamp(TIMESTAMP)) => . ... </k>
+    rule <k> setCurBlockInfo(blockTimestamp(TIMESTAMP)) => .K ... </k>
          <curBlockTimestamp> _ => TIMESTAMP </curBlockTimestamp>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> setCurBlockInfo(blockNonce(NONCE)) => . ... </k>
+    rule <k> setCurBlockInfo(blockNonce(NONCE)) => .K ... </k>
          <curBlockNonce> _ => NONCE </curBlockNonce>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> setCurBlockInfo(blockRound(ROUND)) => . ... </k>
+    rule <k> setCurBlockInfo(blockRound(ROUND)) => .K ... </k>
          <curBlockRound> _ => ROUND </curBlockRound>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> setCurBlockInfo(blockEpoch(EPOCH)) => . ... </k>
+    rule <k> setCurBlockInfo(blockEpoch(EPOCH)) => .K ... </k>
          <curBlockEpoch> _ => EPOCH </curBlockEpoch>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> setCurBlockInfo(blockRandomSeed(SEED)) => . ... </k>
+    rule <k> setCurBlockInfo(blockRandomSeed(SEED)) => .K ... </k>
          <curBlockRandomSeed> _ => SEED </curBlockRandomSeed>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> setPrevBlockInfo(blockTimestamp(TIMESTAMP)) => . ... </k>
+    rule <k> setPrevBlockInfo(blockTimestamp(TIMESTAMP)) => .K ... </k>
          <prevBlockTimestamp> _ => TIMESTAMP </prevBlockTimestamp>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> setPrevBlockInfo(blockNonce(NONCE)) => . ... </k>
+    rule <k> setPrevBlockInfo(blockNonce(NONCE)) => .K ... </k>
          <prevBlockNonce> _ => NONCE </prevBlockNonce>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> setPrevBlockInfo(blockRound(ROUND)) => . ... </k>
+    rule <k> setPrevBlockInfo(blockRound(ROUND)) => .K ... </k>
          <prevBlockRound> _ => ROUND </prevBlockRound>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> setPrevBlockInfo(blockEpoch(EPOCH)) => . ... </k>
+    rule <k> setPrevBlockInfo(blockEpoch(EPOCH)) => .K ... </k>
          <prevBlockEpoch> _ => EPOCH </prevBlockEpoch>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> setPrevBlockInfo(blockRandomSeed(SEED)) => . ... </k>
+    rule <k> setPrevBlockInfo(blockRandomSeed(SEED)) => .K ... </k>
          <prevBlockRandomSeed> _ => SEED </prevBlockRandomSeed>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 ```
 
@@ -295,13 +295,13 @@ Only take the next step once both the Elrond node and Wasm are done executing.
              => checkAccountNonceAux(#address2Bytes(ADDRESS), NONCE) ... </k>
       [priority(60)]
 
-    rule <k> checkAccountNonceAux(ADDR, NONCE) => . ... </k>
+    rule <k> checkAccountNonceAux(ADDR, NONCE) => .K ... </k>
          <account>
            <address> ADDR </address>
            <nonce> NONCE </nonce>
            ...
          </account>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
     syntax Step ::= checkAccountBalance    ( Address, Int ) [klabel(checkAccountBalance), symbol]
@@ -309,16 +309,16 @@ Only take the next step once both the Elrond node and Wasm are done executing.
  // ------------------------------------------------------------------------------------------------
     rule <k> checkAccountBalance(ADDRESS, BALANCE)
              => checkAccountBalanceAux(#address2Bytes(ADDRESS), BALANCE) ... </k>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> checkAccountBalanceAux(ADDR, BALANCE) => . ... </k>
+    rule <k> checkAccountBalanceAux(ADDR, BALANCE) => .K ... </k>
          <account>
            <address> ADDR </address>
            <balance> BALANCE </balance>
            ...
          </account>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
     syntax Step ::= checkAccountESDTBalance    ( Address, Bytes, Int ) [klabel(checkAccountESDTBalance), symbol]
@@ -326,10 +326,10 @@ Only take the next step once both the Elrond node and Wasm are done executing.
  // ------------------------------------------------------------------------------------------------
     rule <k> checkAccountESDTBalance(ADDRESS, TOKEN, BALANCE)
              => checkAccountESDTBalanceAux(#address2Bytes(ADDRESS), TOKEN, BALANCE) ... </k>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> checkAccountESDTBalanceAux(ADDR, TOKEN, BALANCE) => . ... </k>
+    rule <k> checkAccountESDTBalanceAux(ADDR, TOKEN, BALANCE) => .K ... </k>
          <account>
            <address> ADDR </address>
            <esdtData>
@@ -339,7 +339,7 @@ Only take the next step once both the Elrond node and Wasm are done executing.
            </esdtData>
            ...
          </account>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
     syntax Step ::= checkAccountStorage    ( Address, MapBytesToBytes ) [klabel(checkAccountStorage), symbol]
@@ -347,16 +347,16 @@ Only take the next step once both the Elrond node and Wasm are done executing.
  // ------------------------------------------------------------------------------------------------
     rule <k> checkAccountStorage(ADDRESS, STORAGE)
              => checkAccountStorageAux(#address2Bytes(ADDRESS), STORAGE) ... </k>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> checkAccountStorageAux(ADDR, STORAGE) => . ... </k>
+    rule <k> checkAccountStorageAux(ADDR, STORAGE) => .K ... </k>
          <account>
            <address> ADDR </address>
            <storage> ACCTSTORAGE </storage>
            ...
          </account>
-         <commands> . </commands>
+         <commands> .K </commands>
         requires ACCTSTORAGE ==K #removeEmptyBytes(STORAGE)
       [priority(60)]
 
@@ -365,7 +365,7 @@ Only take the next step once both the Elrond node and Wasm are done executing.
  // ---------------------------------------------------------------------------------------------
     rule <k> checkAccountCode(ADDRESS, CODEPATH)
              => checkAccountCodeAux(#address2Bytes(ADDRESS), CODEPATH) ... </k>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
     syntax OptionalString ::= #getModuleCodePath(ModuleDecl)    [function, total]
@@ -375,23 +375,23 @@ Only take the next step once both the Elrond node and Wasm are done executing.
     rule #getModuleCodePath(_) => .String                                                   [owise]
 
     rule [checkAccountCodeAux-no-code]:
-         <k> checkAccountCodeAux(ADDR, "") => . ... </k>
+         <k> checkAccountCodeAux(ADDR, "") => .K ... </k>
          <account>
            <address> ADDR </address>
            <code> .Code </code>
            ...
          </account>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
       
     rule [checkAccountCodeAux-code]:
-         <k> checkAccountCodeAux(ADDR, CODEPATH) => . ... </k>
+         <k> checkAccountCodeAux(ADDR, CODEPATH) => .K ... </k>
          <account>
            <address> ADDR </address>
            <code> CODE:ModuleDecl </code>
            ...
          </account>
-         <commands> . </commands>
+         <commands> .K </commands>
       requires CODEPATH ==K #getModuleCodePath(CODE)
       [priority(60)]
 
@@ -400,27 +400,27 @@ Only take the next step once both the Elrond node and Wasm are done executing.
  // ---------------------------------------------------------------------------------
     rule <k> checkedAccount(ADDRESS)
              => checkedAccountAux(#address2Bytes(ADDRESS)) ... </k>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> checkedAccountAux(ADDR) => . ... </k>
+    rule <k> checkedAccountAux(ADDR) => .K ... </k>
          <checkedAccounts> ... (.Set => SetItem(ADDR)) ... </checkedAccounts>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
     syntax Step ::= checkNoAdditionalAccounts( Set ) [klabel(checkNoAdditionalAccounts), symbol]
  // ---------------------------------------------------------------------------------------
-    rule <k> checkNoAdditionalAccounts(EXPECTED) => . ... </k>
+    rule <k> checkNoAdditionalAccounts(EXPECTED) => .K ... </k>
          <checkedAccounts> CHECKEDACCTS </checkedAccounts>
-         <commands> . </commands>
+         <commands> .K </commands>
       requires EXPECTED ==K CHECKEDACCTS
       [priority(60)]
 
     syntax Step ::= "clearCheckedAccounts" [klabel(clearCheckedAccounts), symbol]
  // -----------------------------------------------------------------------------
-    rule <k> clearCheckedAccounts => . ... </k>
+    rule <k> clearCheckedAccounts => .K ... </k>
          <checkedAccounts> _ => .Set </checkedAccounts>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 ```
 
@@ -434,12 +434,12 @@ Only take the next step once both the Elrond node and Wasm are done executing.
         <k> callTx(FROM, TO, VALUE, ESDT, FUNCTION, ARGS, GASLIMIT, GASPRICE)
          => callTxAux(#address2Bytes(FROM), #address2Bytes(TO), VALUE, ESDT, FUNCTION, ARGS, GASLIMIT, GASPRICE) ... 
         </k>
-        <commands> . </commands>
+        <commands> .K </commands>
       [priority(60)]
 
     rule [callTxAux]:
         <k> callTxAux(FROM, TO, VALUE, ESDT, FUNCTION, ARGS, GASLIMIT, GASPRICE) => #wait ... </k>
-        <commands> . => callContract(TO, FUNCTION, mkVmInputSCCall(FROM, ARGS, VALUE, ESDT, GASLIMIT, GASPRICE)) </commands>
+        <commands> .K => callContract(TO, FUNCTION, mkVmInputSCCall(FROM, ARGS, VALUE, ESDT, GASLIMIT, GASPRICE)) </commands>
         <account>
           <address> FROM </address>
           <nonce> NONCE => NONCE +Int 1 </nonce>
@@ -469,34 +469,34 @@ Only take the next step once both the Elrond node and Wasm are done executing.
 
     syntax Step ::= checkExpectOut ( ListBytes ) [klabel(checkExpectOut), symbol]
  // --------------------------------------------------------------------------
-    rule <k> checkExpectOut(OUT) => . ... </k>
+    rule <k> checkExpectOut(OUT) => .K ... </k>
          <vmOutput> VMOutput(... out: OUT) </vmOutput>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
     syntax Step ::= checkExpectStatus ( ReturnCode ) [klabel(checkExpectStatus), symbol]
  // ------------------------------------------------------------------------------------
-    rule <k> checkExpectStatus(RETURNCODE) => . ... </k>
+    rule <k> checkExpectStatus(RETURNCODE) => .K ... </k>
          <vmOutput> VMOutput(... returnCode: RETURNCODE) </vmOutput>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
     syntax Step ::= checkExpectMessage ( Bytes ) [klabel(checkExpectMessage), symbol]
  // ---------------------------------------------------------------------------------
-    rule <k> checkExpectMessage(MSG) => . ... </k>
+    rule <k> checkExpectMessage(MSG) => .K ... </k>
          <vmOutput> VMOutput(... returnMessage: MSG) </vmOutput>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
     syntax Step ::= checkExpectLogs ( List ) [klabel(checkExpectLogs), symbol]
  // --------------------------------------------------------------------------
-    rule <k> checkExpectLogs(LOGS) => . ... </k>
+    rule <k> checkExpectLogs(LOGS) => .K ... </k>
          <vmOutput> VMOutput(... logs: LOGS) </vmOutput>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
     // TODO implement event logs (some host functions like ESDT transfer should emit event logs. see crowdfunding-claim-successful.json)
-    rule <k> checkExpectLogs(_LOGS) => . ... </k>
-         <commands> . </commands>
+    rule <k> checkExpectLogs(_LOGS) => .K ... </k>
+         <commands> .K </commands>
       [priority(61)]
 
 ```
@@ -513,7 +513,7 @@ TODO make sure that none of the state changes are persisted -- [Doc](https://doc
       [priority(60)]
 
     rule <k> queryTxAux(TO, FUNCTION, ARGS) => #wait ... </k>
-         <commands> . => callContract(TO, FUNCTION, mkVmInputQuery(TO, ARGS)) </commands>
+         <commands> .K => callContract(TO, FUNCTION, mkVmInputQuery(TO, ARGS)) </commands>
       [priority(60)]
 
     syntax VmInputCell ::= mkVmInputQuery(Bytes, ListBytes)    [function, total]
@@ -539,12 +539,12 @@ TODO make sure that none of the state changes are persisted -- [Doc](https://doc
     rule <k> deployTx(FROM, VALUE, MODULE, ARGS, GASLIMIT, GASPRICE)
           => deployTxAux(#address2Bytes(FROM), VALUE, MODULE, ARGS, GASLIMIT, GASPRICE) ... 
          </k>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
     rule [deployTxAux]:
         <k> deployTxAux(FROM, VALUE, MODULE, ARGS, GASLIMIT, GASPRICE) => #wait ... </k>
-        <commands> . 
+        <commands> .K 
                 => createAccount(NEWADDR)
                 ~> setAccountOwner(NEWADDR, FROM)
                 ~> setAccountCode(NEWADDR, MODULE)
@@ -579,7 +579,7 @@ TODO make sure that none of the state changes are persisted -- [Doc](https://doc
     syntax Step ::= transfer(TransferTx) [klabel(transfer), symbol]
  // -----------------------------------------------------
     rule <k> transfer(TX) => TX ... </k>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
     syntax TransferTx ::= transferTx    ( from: Address, to: Bytes, value: Int ) [klabel(transferTx), symbol]
@@ -588,11 +588,11 @@ TODO make sure that none of the state changes are persisted -- [Doc](https://doc
     rule <k> transferTx(FROM, TO, VAL) 
           => transferTxAux(#address2Bytes(FROM), #address2Bytes(TO), VAL) ...
          </k>
-         <commands> . </commands>
+         <commands> .K </commands>
     [priority(60)]
 
     rule <k> transferTxAux(FROM, TO, VAL) => #wait ... </k>
-         <commands> . => transferFunds(FROM, TO, VAL) </commands>
+         <commands> .K => transferFunds(FROM, TO, VAL) </commands>
       [priority(60)]
 ```
 
@@ -602,17 +602,17 @@ TODO make sure that none of the state changes are persisted -- [Doc](https://doc
     syntax Step ::= validatorReward(ValidatorRewardTx) [klabel(validatorReward), symbol]
  // ------------------------------------------------------------------------------------
     rule <k> validatorReward(TX) => TX ... </k>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
     syntax ValidatorRewardTx ::= validatorRewardTx    ( to: Address, value: Int) [klabel(validatorRewardTx), symbol]
                                | validatorRewardTxAux ( to: Bytes, value: Int )  [klabel(validatorRewardTxAux), symbol]
  // -------------------------------------------------------------------------------------------------------------------
     rule <k> validatorRewardTx(TO, VAL) => validatorRewardTxAux(#address2Bytes(TO), VAL) ... </k>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
-    rule <k> validatorRewardTxAux(TO, VAL) => . ... </k>
+    rule <k> validatorRewardTxAux(TO, VAL) => .K ... </k>
          <account>
            <address> TO </address>
             <storage> STOR
@@ -622,7 +622,7 @@ TODO make sure that none of the state changes are persisted -- [Doc](https://doc
             <balance> TO_BAL => TO_BAL +Int VAL </balance>
             ...
          </account>
-         <commands> . </commands>
+         <commands> .K </commands>
       [priority(60)]
 
     syntax Bytes ::= #incBytes(val : Bytes, inc : Int) [function]

--- a/vmhooks/bigIntOps.md
+++ b/vmhooks/bigIntOps.md
@@ -22,7 +22,7 @@ module BIGINT-HELPERS
 
     syntax InternalInstr ::= #getBigInt ( idx : Int ,  Signedness )
  // ---------------------------------------------------------------
-    rule <instrs> #getBigInt(BIGINT_IDX, SIGN) => . ... </instrs>
+    rule <instrs> #getBigInt(BIGINT_IDX, SIGN) => .K ... </instrs>
          <bytesStack> STACK => Int2Bytes(HEAP {{ BIGINT_IDX }} orDefault 0, BE, SIGN) : STACK </bytesStack>
          <bigIntHeap> HEAP </bigIntHeap>
       requires BIGINT_IDX in_keys{{ HEAP }}
@@ -39,7 +39,7 @@ module BIGINT-HELPERS
     syntax InternalInstr ::= #getBigIntOrCreate ( idx : Int ,  Signedness )
  // ---------------------------------------------------------------
     rule [getBigIntOrCreate-get]:
-        <instrs> #getBigIntOrCreate(BIGINT_IDX, SIGN) => . ... </instrs>
+        <instrs> #getBigIntOrCreate(BIGINT_IDX, SIGN) => .K ... </instrs>
         <bytesStack> STACK => Int2Bytes(HEAP {{ BIGINT_IDX }} orDefault 0, BE, SIGN) : STACK </bytesStack>
         <bigIntHeap> HEAP </bigIntHeap>
       requires BIGINT_IDX in_keys{{ HEAP }}
@@ -62,10 +62,10 @@ module BIGINT-HELPERS
     rule <instrs> #setBigIntFromBytesStack(BIGINT_IDX, SIGN) => #setBigInt(BIGINT_IDX, BS, SIGN) ... </instrs>
          <bytesStack> BS : _ </bytesStack>
 
-    rule <instrs> #setBigInt(BIGINT_IDX, BS, SIGN) => . ... </instrs>
+    rule <instrs> #setBigInt(BIGINT_IDX, BS, SIGN) => .K ... </instrs>
          <bigIntHeap> HEAP => HEAP {{ BIGINT_IDX <- Bytes2Int(BS, BE, SIGN) }} </bigIntHeap>
 
-    rule <instrs> #setBigIntValue(BIGINT_IDX, VALUE) => . ... </instrs>
+    rule <instrs> #setBigIntValue(BIGINT_IDX, VALUE) => .K ... </instrs>
          <bigIntHeap> HEAP => HEAP {{ BIGINT_IDX <- VALUE }} </bigIntHeap>
 
     syntax Int ::= #newKey(Map)                    [function, total]
@@ -237,7 +237,7 @@ module BIGINTOPS
       //    check for its definedness separately.
 
     // extern void bigIntAdd(void* context, int32_t destination, int32_t op1, int32_t op2);
-    rule <instrs> hostCall("env", "bigIntAdd", [ i32 i32 i32 .ValTypes ] -> [ .ValTypes ]) => . ... </instrs>
+    rule <instrs> hostCall("env", "bigIntAdd", [ i32 i32 i32 .ValTypes ] -> [ .ValTypes ]) => .K ... </instrs>
          <locals> 0 |-> <i32> DST  1 |-> <i32> OP1_IDX  2 |-> <i32> OP2_IDX </locals>
          <bigIntHeap> HEAP
                    => HEAP {{ DST <- (HEAP{{OP1_IDX}} orDefault 0) +Int (HEAP{{OP2_IDX}} orDefault 0) }}
@@ -262,7 +262,7 @@ module BIGINTOPS
         orBool notBool (OP2_IDX in_keys{{HEAP}})
 
     // extern void bigIntSub(void* context, int32_t destination, int32_t op1, int32_t op2);
-    rule <instrs> hostCall("env", "bigIntSub", [ i32 i32 i32 .ValTypes ] -> [ .ValTypes ]) => . ... </instrs>
+    rule <instrs> hostCall("env", "bigIntSub", [ i32 i32 i32 .ValTypes ] -> [ .ValTypes ]) => .K ... </instrs>
          <locals> 0 |-> <i32> DST  1 |-> <i32> OP1_IDX  2 |-> <i32> OP2_IDX </locals>
          <bigIntHeap> HEAP
                    => HEAP {{ DST <- (HEAP{{OP1_IDX}} orDefault 0) -Int (HEAP{{OP2_IDX}} orDefault 0) }}
@@ -285,7 +285,7 @@ module BIGINTOPS
         orBool notBool (OP2_IDX in_keys{{HEAP}})
 
     // extern void bigIntMul(void* context, int32_t destination, int32_t op1, int32_t op2);
-    rule <instrs> hostCall("env", "bigIntMul", [ i32 i32 i32 .ValTypes ] -> [ .ValTypes ]) => . ... </instrs>
+    rule <instrs> hostCall("env", "bigIntMul", [ i32 i32 i32 .ValTypes ] -> [ .ValTypes ]) => .K ... </instrs>
          <locals> 0 |-> <i32> DST  1 |-> <i32> OP1_IDX  2 |-> <i32> OP2_IDX </locals>
          <bigIntHeap> HEAP
                    => HEAP {{ DST <- (HEAP{{OP1_IDX}} orDefault 0) *Int (HEAP{{OP2_IDX}} orDefault 0) }}
@@ -308,7 +308,7 @@ module BIGINTOPS
         orBool notBool (OP2_IDX in_keys{{HEAP}})
 
     // extern void bigIntTDiv(void* context, int32_t destination, int32_t op1, int32_t op2);
-    rule <instrs> hostCall("env", "bigIntTDiv", [ i32 i32 i32 .ValTypes ] -> [ .ValTypes ]) => . ... </instrs>
+    rule <instrs> hostCall("env", "bigIntTDiv", [ i32 i32 i32 .ValTypes ] -> [ .ValTypes ]) => .K ... </instrs>
          <locals> 0 |-> <i32> DST  1 |-> <i32> OP1_IDX  2 |-> <i32> OP2_IDX </locals>
          <bigIntHeap> HEAP
                    => HEAP {{ DST <- (HEAP{{OP1_IDX}} orDefault 0) /Int (HEAP{{OP2_IDX}} orDefault 0) }}
@@ -430,7 +430,7 @@ module BIGINTOPS
          </locals>
 
     // extern void bigIntGetUnsignedArgument(void *context, int32_t id, int32_t destination);
-    rule <instrs> hostCall("env", "bigIntGetUnsignedArgument", [ i32 i32 .ValTypes ] -> [ .ValTypes ]) =>  . ... </instrs>
+    rule <instrs> hostCall("env", "bigIntGetUnsignedArgument", [ i32 i32 .ValTypes ] -> [ .ValTypes ]) =>  .K ... </instrs>
          <locals> 0 |-> <i32> ARG_IDX  1 |-> <i32> BIG_IDX </locals>
          <callArgs> ARGS </callArgs>
          <bigIntHeap> HEAP => HEAP {{ BIG_IDX <- Bytes2Int(ARGS {{ ARG_IDX }}, BE, Unsigned) }} </bigIntHeap>
@@ -444,13 +444,13 @@ module BIGINTOPS
 
     // If ARG_IDX is invalid (out of bounds) just ignore
     // https://github.com/multiversx/mx-chain-vm-go/blob/ea3d78d34c35f7ef9c1a9ea4fce8288608763229/vmhost/vmhooks/bigIntOps.go#L68
-    rule <instrs> hostCall("env", "bigIntGetUnsignedArgument", [ i32 i32 .ValTypes ] -> [ .ValTypes ]) =>  . ... </instrs>
+    rule <instrs> hostCall("env", "bigIntGetUnsignedArgument", [ i32 i32 .ValTypes ] -> [ .ValTypes ]) =>  .K ... </instrs>
          <locals> 0 |-> <i32> ARG_IDX  1 |-> <i32> _BIG_IDX </locals>
          <callArgs> ARGS </callArgs>
       requires notBool #validArgIdx(ARG_IDX, ARGS)
 
     // extern void bigIntGetSignedArgument(void *context, int32_t id, int32_t destination);
-    rule <instrs> hostCall("env", "bigIntGetSignedArgument", [ i32 i32 .ValTypes ] -> [ .ValTypes ]) =>  . ... </instrs>
+    rule <instrs> hostCall("env", "bigIntGetSignedArgument", [ i32 i32 .ValTypes ] -> [ .ValTypes ]) =>  .K ... </instrs>
          <locals> 0 |-> <i32> ARG_IDX  1 |-> <i32> BIG_IDX </locals>
          <callArgs> ARGS </callArgs>
          <bigIntHeap> HEAP => HEAP {{ BIG_IDX <- Bytes2Int(ARGS {{ ARG_IDX }}, BE, Signed) }} </bigIntHeap>
@@ -461,13 +461,13 @@ module BIGINTOPS
       //  - Bytes2Int is total
       //  - _{{_ <- _}} is total
 
-    rule <instrs> hostCall("env", "bigIntGetSignedArgument", [ i32 i32 .ValTypes ] -> [ .ValTypes ]) =>  . ... </instrs>
+    rule <instrs> hostCall("env", "bigIntGetSignedArgument", [ i32 i32 .ValTypes ] -> [ .ValTypes ]) =>  .K ... </instrs>
          <locals> 0 |-> <i32> ARG_IDX  1 |-> <i32> _BIG_IDX </locals>
          <callArgs> ARGS </callArgs>
       requires notBool #validArgIdx(ARG_IDX, ARGS)
 
     // extern void bigIntGetCallValue(void *context, int32_t destination);
-    rule <instrs> hostCall("env", "bigIntGetCallValue", [ i32 .ValTypes ] -> [ .ValTypes ]) => . ... </instrs>
+    rule <instrs> hostCall("env", "bigIntGetCallValue", [ i32 .ValTypes ] -> [ .ValTypes ]) => .K ... </instrs>
          <locals> 0 |-> <i32> IDX </locals>
          <bigIntHeap> HEAP => HEAP {{ IDX <- VALUE }} </bigIntHeap>
          <callValue> VALUE </callValue>

--- a/vmhooks/cryptoei.md
+++ b/vmhooks/cryptoei.md
@@ -17,12 +17,12 @@ module CRYPTOEI-HELPERS
 
     syntax HashBytesStackInstr ::= "#sha256FromBytesStack"
  // ------------------------------------------------------
-    rule <instrs> #sha256FromBytesStack => . ... </instrs>
+    rule <instrs> #sha256FromBytesStack => .K ... </instrs>
          <bytesStack> (DATA => #parseHexBytes(Sha256(DATA))) : _STACK </bytesStack>
 
     syntax HashBytesStackInstr ::= "#keccakFromBytesStack"
  // ------------------------------------------------------
-    rule <instrs> #keccakFromBytesStack => . ... </instrs>
+    rule <instrs> #keccakFromBytesStack => .K ... </instrs>
          <bytesStack> (DATA => #parseHexBytes(Keccak256(DATA))) : _STACK </bytesStack>
 
     syntax InternalInstr ::= #hashMemory ( Int , Int , Int ,  HashBytesStackInstr )

--- a/vmhooks/manBufOps.md
+++ b/vmhooks/manBufOps.md
@@ -32,7 +32,7 @@ module MANBUFOPS
     syntax InternalInstr ::= #getBuffer ( idx : Int )
  // ---------------------------------------------------------------
     rule [getBuffer]:
-        <instrs> #getBuffer(BUFFER_IDX) => . ... </instrs>
+        <instrs> #getBuffer(BUFFER_IDX) => .K ... </instrs>
         <bytesStack> STACK => HEAP{{BUFFER_IDX}} orDefault .Bytes : STACK </bytesStack>
         <bufferHeap> HEAP </bufferHeap>
       requires #validBufferId(BUFFER_IDX, HEAP)
@@ -51,7 +51,7 @@ module MANBUFOPS
     rule <instrs> #setBufferFromBytesStack(BUFFER_IDX) => #setBuffer(BUFFER_IDX, BS) ... </instrs>
          <bytesStack> BS : _ </bytesStack>
 
-    rule <instrs> #setBuffer(BUFFER_IDX, BS) => . ... </instrs>
+    rule <instrs> #setBuffer(BUFFER_IDX, BS) => .K ... </instrs>
          <bufferHeap> HEAP => HEAP {{ BUFFER_IDX <- BS }} </bufferHeap>
 
     syntax InternalInstr ::= #appendBytesToBuffer( Int )
@@ -64,12 +64,12 @@ module MANBUFOPS
                   ... 
          </instrs>
 
-    rule <instrs> #appendBytes => . ... </instrs>
+    rule <instrs> #appendBytes => .K ... </instrs>
          <bytesStack> BS1 : BS2 : BSS => (BS1 +Bytes BS2) : BSS </bytesStack>
 
     syntax InternalInstr ::= #sliceBytes( Int , Int )
  // ------------------------------------------------------------------
-    rule <instrs> #sliceBytes(OFFSET, LENGTH) => . ... </instrs>
+    rule <instrs> #sliceBytes(OFFSET, LENGTH) => .K ... </instrs>
          <bytesStack> (BS => substrBytes(BS, OFFSET, OFFSET +Int LENGTH)) : _ </bytesStack>
          requires #sliceBytesInBounds( BS , OFFSET , LENGTH )
 

--- a/vmhooks/managedConversions.md
+++ b/vmhooks/managedConversions.md
@@ -22,7 +22,7 @@ module MANAGEDCONVERSIONS
                ~> #writeEsdtsToBytesH(L) ...
          </instrs>
     
-    rule <instrs> #writeEsdtsToBytesH(.List) => . ... </instrs>
+    rule <instrs> #writeEsdtsToBytesH(.List) => .K ... </instrs>
 
     rule <instrs> #writeEsdtsToBytesH(Ts ListItem(T))
                => #writeEsdtToBytes(T)
@@ -131,7 +131,7 @@ module MANAGEDCONVERSIONS
         </instrs>
     
     rule [writeListBytesToBuffersH-nil]:
-        <instrs> #writeListBytesToBuffersH(.ListBytes) => . ... </instrs>
+        <instrs> #writeListBytesToBuffersH(.ListBytes) => .K ... </instrs>
 
     rule [writeListBytesToBuffersH-cons]:
         <instrs> #writeListBytesToBuffersH(Ts ListItem(wrap(T)))

--- a/vmhooks/managedei.md
+++ b/vmhooks/managedei.md
@@ -29,7 +29,7 @@ module MANAGEDEI
     // TODO implement managedWriteLog
     // extern void      managedWriteLog(void* context, int32_t topicsHandle, int32_t dataHandle);
     rule <instrs> hostCall ( "env" , "managedWriteLog" , [ i32  i32  .ValTypes ] -> [ .ValTypes ] )
-               => .
+               => .K
                   ...
          </instrs>
 


### PR DESCRIPTION
This PR is part of https://github.com/runtimeverification/k/pull/4017; the syntax `.` for empty K sequences will be deprecated and removed in a future version of K. Ahead of this change, I am proactively updating active projects to minimise the noise they receive when the deprecation is actually enabled.